### PR TITLE
Test 1.10 on Metal and oneAPI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -62,6 +62,7 @@ steps:
         version:
           - "1.8"
           - "1.9"
+          - "1.10"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"
@@ -90,6 +91,7 @@ steps:
         version:
           - "1.8"
           - "1.9"
+          - "1.10"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"


### PR DESCRIPTION
Apparently, DiffEqGPU is working incorrectly on v1.10 on Metal: https://buildkite.com/julialang/diffeqgpu-dot-jl/builds/1006#018cf9e1-e6db-42da-b270-1afbf733a6d4